### PR TITLE
enable UTF-8 encoding

### DIFF
--- a/deeplab_resnet/hc_deeplab.py
+++ b/deeplab_resnet/hc_deeplab.py
@@ -1,3 +1,5 @@
+# - *- coding: utf- 8 - *-
+
 """
 @author: Tae-Hyun Oh (http://taehyunoh.com, taehyun@csail.mit.edu)
 @date: Jul 29, 2018


### PR DESCRIPTION
https://github.com/iyah4888/SIGGRAPH18SSS/issues/15

SyntaxError: Non-ASCII character '\xc4' in file /SIGGRAPH18SSS-master/deeplab_resnet/hc_deeplab.py on line 7, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

The above error message is displayed by Python when character encoding set other then ASCII is used withing your codebase.

Solution here is to add this to the top of your hc_deeplab.py file in deeplab_resnet folder to enable UTF-8 encoding: